### PR TITLE
fix build on macOS 10.14

### DIFF
--- a/examples/wscript
+++ b/examples/wscript
@@ -8,7 +8,7 @@ def build(bld):
     def example(tgt, extra_use=[]):
         bld.program(
                 source='{}.c'.format(tgt),
-                use=['rutabaga', 'rtb_style_default'] + extra_use,
+                use=['rutabaga', 'rtb_style_default', 'FREETYPE2'] + extra_use,
                 target=tgt)
 
     example('test')

--- a/wscript
+++ b/wscript
@@ -157,6 +157,8 @@ def configure(conf):
         conf.env.PLATFORM = 'cocoa'
 
         conf.env.append_unique('FRAMEWORK_COCOA', ['Cocoa', 'QuartzCore'])
+        # NSOpenGL* became deprecated in macOS 10.14
+        conf.env.append_unique('CFLAGS', ['-Wno-deprecated'])
     else:
         check_alloca(conf)
         check_gl(conf)


### PR DESCRIPTION
Trying to build on macOS 10.14.4 I got a lot of deprecation warnings failing build related to NSOpenGL* stuff first, and then linker error related to freetype symbols. This PR fixes both problems.