### PR TITLE
improve text rendering on fraction scaling

### DIFF
--- a/include/rutabaga/window.h
+++ b/include/rutabaga/window.h
@@ -88,6 +88,8 @@ struct rtb_window {
 	struct rtb_point scale;
 	struct rtb_point scale_recip;
 
+	float x_fractional_correction;
+
 	struct rutabaga *rtb;
 
 	GLuint vao;

--- a/src/surface.c
+++ b/src/surface.c
@@ -88,7 +88,9 @@ reflow(struct rtb_element *elem, struct rtb_element *instigator,
 	}
 
 	mat4_set_orthographic(&self->render_ctx.projection,
-			self->x,
+			// for some reason, shifting a surface horizontally by a tiny amount
+			// greatly improves the rendering of text when using a fractional scaling
+			self->x + self->window->x_fractional_correction,
 			self->x + self->w,
 			self->y + self->h,
 			self->y,

--- a/src/window.c
+++ b/src/window.c
@@ -25,6 +25,7 @@
  */
 
 #include <assert.h>
+#include <math.h>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -455,6 +456,14 @@ rtb_window_open(struct rutabaga *r, const struct rtb_window_open_options *opt)
 
 	if (RTB_SUBCLASS(RTB_SURFACE(self), rtb_surface_init, &super))
 		goto err_surface_init;
+
+	// for some reason, shifting a surface horizontally by a tiny amount
+	// greatly improves the rendering of text when using a fractional scaling
+	if (fabsf(self->scale.x - roundf(self->scale.x)) < 0.0001) {
+		self->x_fractional_correction = 0.0;
+	} else {
+		self->x_fractional_correction = 0.01;
+	}
 
 	self->w = opt->width  * self->scale_recip.x;
 	self->h = opt->height * self->scale_recip.y;


### PR DESCRIPTION
I'm not sure why, but shifting the canvas's projection matrix horizontally by a tiny amount greatly improves the rendering of text when using a fractional scaling. Maybe it's something do with rounding errors with the projection matrix or how the sampler samples a texture?

It's still not perfect though, some scale factors like 1.7 still look kind-of janky (although it is much better than it was before). However, it does seem to be almost perfect when using an "even" fractional scaling amount like 1.5, 1.25, 1.75, 1.125, etc.

I spent all day trying to find for a proper, less "hacky" solution, but I just can't seem to find the issue. Even rounding every vertex position inside the shader itself didn't fix it. At least this is better than nothing for now.